### PR TITLE
Ignore noinline dependant functions.

### DIFF
--- a/lib/IR/RepoTicket.cpp
+++ b/lib/IR/RepoTicket.cpp
@@ -138,9 +138,14 @@ updateDigestUseCallDependencies(const GlobalObject *GO, MD5 &GOHash,
   auto Dependencies = UpdateDigestAndGetDependencies(GO, GOHash, GOIMap);
 
   // Recursively for all the dependent global objects.
-  for (const GlobalObject *D : Dependencies)
+  for (const GlobalObject *D : Dependencies) {
+    const llvm::Function *Fn = dyn_cast<const llvm::Function>(D);
+    // if function will not be inlined, skip it
+    if (Fn && Fn->hasFnAttribute(Attribute::NoInline))
+      continue;
     updateDigestUseCallDependencies(D, GOHash, Visited, GOIMap,
                                     UpdateDigestAndGetDependencies);
+  }
 }
 
 std::tuple<bool, unsigned, unsigned> generateTicketMDs(Module &M) {


### PR DESCRIPTION
Do not include dependant functions if they are marked noinline. This helps -O0 builds as all functions get marked noinline. 