### PR TITLE
Adding the missing linkage type.

### DIFF
--- a/lib/MC/RepoObjectWriter.cpp
+++ b/lib/MC/RepoObjectWriter.cpp
@@ -562,6 +562,7 @@ RepoObjectWriter::toPstoreLinkage(GlobalValue::LinkageTypes L) {
     return pstore::repo::linkage_type::external;
   case GlobalValue::LinkOnceAnyLinkage:
   case GlobalValue::LinkOnceODRLinkage:
+  case GlobalValue::WeakAnyLinkage:
   case GlobalValue::WeakODRLinkage:
     return pstore::repo::linkage_type::linkonce;
   case GlobalValue::PrivateLinkage:


### PR DESCRIPTION
The fix is a part of issue 51.

When compiling the llvm-prepo project targeted on Repo using the built llvm-prepo toolchain, the "unsupported linkage type" error is met.